### PR TITLE
Minor documentation update for oh-my-zsh

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,14 +74,14 @@ is the directory with custom plugins of oh-my-zsh `(read more) <https://github.c
 
 ::
 
-    git clone https://github.com/MichaelAquilina/zsh-history-filter.git $ZSH_CUSTOM/plugins/history-filter
+    git clone https://github.com/MichaelAquilina/zsh-history-filter.git $ZSH_CUSTOM/plugins/zsh-history-filter
 
 
 Then add this line to your ``.zshrc``
 
 ::
 
-    plugins=(history-filter $plugins)
+    plugins=(zsh-history-filter $plugins)
 
 Rewrite History
 ---------------


### PR DESCRIPTION
Hi. Thanks for the great work, I just started using your plugins and it's been great.

However, I found a little bug inside the README about installation on oh-my-zsh. The current README uses the name `history-filter` instead of `zsh-history-filter` make oh-my-zsh unable to load the plugin since it cannot find any `history-filter.plugin.zsh` file inside the directory.

I had change the README a little bit to use only a single name `zsh-history-filter` so every thing can work properly.

Hope you can take a look and merge soon.